### PR TITLE
Add "conditions" optional Array option, for predefined custom S3 Policy "conditions"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,8 @@
 
 # s3-policy
 
-  S3 policy generation for client-side uploads
+  [S3 policy][] generation for client-side uploads. By default, `Content-Type` and
+  `Content-Length` form fields are __required__, but can contain any value.
 
 ## Options
 
@@ -37,7 +38,7 @@ console.log(p.policy);
 console.log(p.signature);
 ```
 
-## License 
+## License
 
 (The MIT License)
 
@@ -61,3 +62,5 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+[S3 policy]: http://docs.aws.amazon.com/AmazonS3/latest/dev/HTTPPOSTForms.html#HTTPPOSTConstructPolicy

--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,7 @@ Create an s3 policy and signature via `opts`:
  - `name` restrict key to prefix [""]
  - `type` restrict content-type prefix [""]
  - `length` max size restriction
+ *  - `conditions` an optional Array of custom "conditions" to include in the policy
 
 An object with `.signature` and `.policy` is returned.
 

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ Create an s3 policy and signature via `opts`:
  - `name` restrict key to prefix [""]
  - `type` restrict content-type prefix [""]
  - `length` max size restriction
- *  - `conditions` an optional Array of custom "conditions" to include in the policy
+ - `conditions` an optional Array of custom "conditions" to include in the policy
 
 An object with `.signature` and `.policy` is returned.
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var crypto = require('crypto');
  *  - `name` restrict object name to prefix [""]
  *  - `type` restrict content-type prefix [""]
  *  - `length` max size restriction
+ *  - `conditions` an optional Array of custom "conditions" to include in the policy
  *
  * An object with `.signature` and `.policy` is returned.
  *
@@ -26,8 +27,7 @@ var crypto = require('crypto');
 module.exports = function(opts){
   var ret = {};
 
-  opts.conditions = [];
-
+  if (!Array.isArray(opts.conditions)) opts.conditions = [];
   opts.conditions.push(['starts-with', '$key', opts.name || '']);
   opts.conditions.push(['starts-with', '$Content-Type', opts.type || '']);
   opts.conditions.push(['starts-with', '$Content-Length', '']);

--- a/index.js
+++ b/index.js
@@ -19,13 +19,13 @@ var crypto = require('crypto');
  * An object with `.signature` and `.policy` is returned.
  *
  * @param {Object} opts
- * @return {Object} 
+ * @return {Object}
  * @api public
  */
 
 module.exports = function(opts){
   var ret = {};
-  
+
   opts.conditions = [];
 
   opts.conditions.push(['starts-with', '$key', opts.name || '']);
@@ -38,7 +38,7 @@ module.exports = function(opts){
 
   ret.policy = policy(opts);
   ret.signature = signature(ret.policy, opts.secret);
-  
+
   return ret;
 };
 
@@ -59,7 +59,7 @@ function policy(opts) {
   var conds = opts.conditions || [];
   conds.push({ bucket: opts.bucket });
   conds.push({ acl: opts.acl });
-  
+
   var policy = {
     expiration: opts.expires.toISOString(),
     conditions: conds

--- a/index.js
+++ b/index.js
@@ -60,12 +60,12 @@ function policy(opts) {
   conds.push({ bucket: opts.bucket });
   conds.push({ acl: opts.acl });
 
-  var policy = {
+  var data = {
     expiration: opts.expires.toISOString(),
     conditions: conds
   };
 
-  var json = JSON.stringify(policy);
+  var json = JSON.stringify(data);
   var base = new Buffer(json).toString('base64');
   return base;
 }


### PR DESCRIPTION
Can be used to add _other_ "conditions". For example, to allow the `Cache-Control` header to be passed in, then you would do something like:

``` js
var policy = require('s3-policy');

var p = policy({
  secret: 'something',
  bucket: 'i.cloudup.com',
  key: 'asdfasdfaewrw',
  acl: 'public-read',
  conditions: [
    ['starts-with', '$Cache-Control', '']
  ]
});
```

Future thoughts: we could potentially add a `headers` Object option, which would streamline the above logic, however the list of allowed headers is very small, so it might not be worth it.
