### PR TITLE
remove rule [starts-with, -Length, ]

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ module.exports = function(opts){
   if (!Array.isArray(opts.conditions)) opts.conditions = [];
   opts.conditions.push(['starts-with', '$key', opts.name || '']);
   opts.conditions.push(['starts-with', '$Content-Type', opts.type || '']);
-  opts.conditions.push(['starts-with', '$Content-Length', '']);
 
   if (opts.length) {
     opts.conditions.push(['content-length-range', 1, opts.length]);


### PR DESCRIPTION
I do know if this rule is really necessary.

I use ng-s3upload, and this rule conflict with their, 
and I see a rule in your module, called 'content-length-range', with range between 1, and length passed to module, wit this rule, starts-with Content-Length is really necessary? If no, my pull request remove, if yes, I suggest more one opts, to module, what you think?
