### PR TITLE
Removed invalid condition

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,7 @@
 
 # s3-policy
 
-  [S3 policy][] generation for client-side uploads. By default, `Content-Type` and
-  `Content-Length` form fields are __required__, but can contain any value.
+  [S3 policy][] generation for client-side uploads. Based on http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html
 
 ## Options
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ module.exports = function(opts){
   if (!Array.isArray(opts.conditions)) opts.conditions = [];
   opts.conditions.push(['starts-with', '$key', opts.name || '']);
   opts.conditions.push(['starts-with', '$Content-Type', opts.type || '']);
-  opts.conditions.push(['starts-with', '$Content-Length', '']);
 
   if (opts.length) {
     opts.conditions.push(['content-length-range', 1, opts.length]);


### PR DESCRIPTION
Passing `["starts-with","$Content-Length",'']`will result in a S3 403 error with the following output:

```
<?xml version="1.0" encoding="UTF-8"?>
<Error>
  <Code>AccessDenied</Code>
  <Message>
    Invalid according to Policy: Policy Condition failed: ["starts-with"
, "$Content-Length", ""]
  </Message>
  <RequestId>...</RequestId>
  <HostId>...</HostId>
</Error>
```
This field is no longer part of the S3 API.  This patch simply removes it from the policy object and updates the `readme.md` referencing the latest documentation http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html.